### PR TITLE
New feature: search_for_highlighted_words

### DIFF
--- a/highlight.py
+++ b/highlight.py
@@ -22,7 +22,7 @@ chars_to_strip = "."
 word_separators = [" ", "\n"]
 # Choose whether you want to build words_to_highlight by searching for already highlighted words
 search_for_highlighted_words = True
-# Choose how many times a word has to highlighted before it gets added to words_to_highlight in get_highlighted_words
+# Choose how many times a word has to be highlighted before it gets added to words_to_highlight in get_highlighted_words
 # NOTE: only works when search_for_highlighted_words is True
 minimum_instances_of_highlighted_word = 1
 

--- a/highlight.py
+++ b/highlight.py
@@ -43,8 +43,7 @@ def highlight_words(file):
 
         else:
             if current_word.strip(chars_to_strip) in words_to_highlight and not wrapping:
-                if contents[i:i + len(wrapper)] != wrapper:
-                    current_word = wrapper + current_word[:len(current_word.strip(chars_to_strip))] + wrapper + current_word[len(current_word.strip(chars_to_strip)):]
+                current_word = wrapper + current_word[:len(current_word.strip(chars_to_strip))] + wrapper + current_word[len(current_word.strip(chars_to_strip)):]
 
             result.append(current_word)
             result.append(ch)
@@ -68,7 +67,9 @@ def find_files_to_look_in():
                 queue.append(os.path.join(file, temp_file))
 
         elif os.path.basename(file) in files_to_look_in:
-            highlight_words(file)
+            yield file
 
 
-find_files_to_look_in()
+files = find_files_to_look_in()
+for file in files:
+    highlight_words(file)

--- a/highlight.py
+++ b/highlight.py
@@ -30,8 +30,9 @@ if search_for_highlighted_words:
     word_count = {}
     temp_words_to_highlight = set()
 
-def highlight_words(file):
-    with open(file, "r") as f:
+
+def highlight_words(current_file):
+    with open(current_file, "r") as f:
         contents = f.read()
 
     result = []
@@ -51,18 +52,20 @@ def highlight_words(file):
 
         else:
             if current_word.strip(chars_to_strip) in words_to_highlight and not wrapping:
-                current_word = wrapper + current_word[:len(current_word.strip(chars_to_strip))] + wrapper + current_word[len(current_word.strip(chars_to_strip)):]
+                current_word = (wrapper + current_word[:len(current_word.strip(chars_to_strip))]
+                                + wrapper + current_word[len(current_word.strip(chars_to_strip)):])
 
             result.append(current_word)
             result.append(ch)
             current_word = ""
 
-    with open(file, "w") as f:
+    with open(current_file, "w") as f:
         result.pop()
         f.write("".join(result))
 
-def get_highlighted_words(file):
-    with open(file, "r") as f:
+
+def get_highlighted_words(current_file):
+    with open(current_file, "r") as f:
         contents = f.read()
 
     contents += "0"
@@ -130,10 +133,10 @@ def find_files_to_look_in():
     return files
 
 
-files = find_files_to_look_in()
+files_found = find_files_to_look_in()
 
 
 if search_for_highlighted_words:
     words_to_highlight = list(temp_words_to_highlight)
-    for file in files:
+    for file in files_found:
         highlight_words(file)

--- a/highlight.py
+++ b/highlight.py
@@ -24,8 +24,11 @@ word_separators = [" ", "\n"]
 search_for_highlighted_words = True
 # Choose how many times a word has to highlighted before it gets added to words_to_highlight in get_highlighted_words
 # NOTE: only works when search_for_highlighted_words is True
-minimum_instances_of_highlighted_word = 4
+minimum_instances_of_highlighted_word = 1
 
+if search_for_highlighted_words:
+    word_count = {}
+    temp_words_to_highlight = set()
 
 def highlight_words(file):
     with open(file, "r") as f:
@@ -58,80 +61,79 @@ def highlight_words(file):
         result.pop()
         f.write("".join(result))
 
-def get_highlighted_words():
-    word_count = {}
-    temp_words_to_highlight = set()
-    for file in files:
-        with open(file, "r") as f:
-            contents = f.read()
+def get_highlighted_words(file):
+    with open(file, "r") as f:
+        contents = f.read()
 
-        wrapping = None
-        word_to_highlight = ""
-        i = 1
-        while i < len(contents) - 1:
-            if wrapping:
-                if contents[i - len(wrapping):i] == wrapping and not contents[i].isalpha():
-                    wrapping = None
-
-                i += 1
-                continue
-
-            if len(word_to_highlight) > 0:
-                if contents[i:i + len(wrapper)] == wrapper:
-                    if word_to_highlight in word_count:
-                        word_count[word_to_highlight] += 1
-                    else:
-                        word_count[word_to_highlight] = 1
-
-                    if word_count[word_to_highlight] >= minimum_instances_of_highlighted_word:
-                        temp_words_to_highlight.add(word_to_highlight)
-
-                    word_to_highlight = ""
-                    i += len(wrapper) + 1
-                    continue
-
-                word_to_highlight += contents[i]
-
-            if contents[i - len(wrapper):i] == wrapper:
-                if not wrapping:
-                    for wrapper_to_ignore, key in wrappers_to_ignore.items():
-                        if contents[i - 1:len(wrapper_to_ignore)] == wrapper_to_ignore:
-                            wrapping = key
-                            i += 1
-
-                    if wrapping:
-                        continue
-
-                word_to_highlight += contents[i]
+    contents += "0"
+    wrapping = None
+    word_to_highlight = ""
+    i = 1
+    while i < len(contents):
+        if wrapping:
+            if contents[i - len(wrapping):i] == wrapping and not contents[i].isalpha():
+                wrapping = None
 
             i += 1
+            continue
 
-    return list(temp_words_to_highlight)
+        if len(word_to_highlight) > 0:
+            if contents[i:i + len(wrapper)] == wrapper:
+                if word_to_highlight in word_count:
+                    word_count[word_to_highlight] += 1
+                else:
+                    word_count[word_to_highlight] = 1
 
+                if word_count[word_to_highlight] >= minimum_instances_of_highlighted_word:
+                    temp_words_to_highlight.add(word_to_highlight)
 
+                word_to_highlight = ""
+                i += len(wrapper) + 1
+                continue
+
+            word_to_highlight += contents[i]
+
+        if contents[i - len(wrapper):i] == wrapper:
+            if not wrapping:
+                for wrapper_to_ignore, key in wrappers_to_ignore.items():
+                    if contents[i - 1:len(wrapper_to_ignore)] == wrapper_to_ignore:
+                        wrapping = key
+
+                if wrapping:
+                    continue
+
+            word_to_highlight += contents[i]
+
+        i += 1
 
 
 def find_files_to_look_in():
     queue = deque(os.listdir())
+    files = []
 
     while len(queue):
-        file = queue.pop()
-        if os.path.abspath(file) in paths_to_ignore:
+        current_file = queue.pop()
+        if os.path.abspath(current_file) in paths_to_ignore:
             continue
 
-        if os.path.isdir(file):
-            for temp_file in os.listdir(file):
-                queue.append(os.path.join(file, temp_file))
+        if os.path.isdir(current_file):
+            for temp_file in os.listdir(current_file):
+                queue.append(os.path.join(current_file, temp_file))
 
-        elif os.path.basename(file) in files_to_look_in:
-            yield file
+        elif os.path.basename(current_file) in files_to_look_in:
+            if search_for_highlighted_words:
+                get_highlighted_words(current_file)
+                files.append(current_file)
+            else:
+                highlight_words(current_file)
+
+    return files
 
 
-files = list(find_files_to_look_in())
+files = find_files_to_look_in()
+
 
 if search_for_highlighted_words:
-    words_to_highlight = get_highlighted_words()
-
-
-for file in files:
-    highlight_words(file)
+    words_to_highlight = list(temp_words_to_highlight)
+    for file in files:
+        highlight_words(file)


### PR DESCRIPTION
With how we're checking the matches now, `if contents[i:i + len(wrapper)] != wrapper:` doesn't seem to be necessary. 

New feature: search_for_highlighted_words. Useful for old dojos, that want to make sure that highlighting is uniform across all words.

Building upon this new feature, I added another feature, called `minimum_instances_of_highlighted_word`, that lets you set a minimum amount of times a word has to appear before `get_highlighted_words` adds that word to `words_to_highlight`.